### PR TITLE
Handle IA5String (7 bit ASCII)

### DIFF
--- a/JavaLibrary/src/main/java/org/bn/coders/per/PERCoderUtils.java
+++ b/JavaLibrary/src/main/java/org/bn/coders/per/PERCoderUtils.java
@@ -58,6 +58,7 @@ public class PERCoderUtils {
     
     public static boolean is7BitEncodedString(ElementInfo elementInfo) {
         int stringType = CoderUtils.getStringTagForElement(elementInfo);
-        return stringType == UniversalTag.PrintableString || stringType == UniversalTag.VisibleString;
+        return stringType == UniversalTag.PrintableString || stringType == UniversalTag.VisibleString ||
+                stringType == UniversalTag.IA5String;
     }
 }

--- a/JavaLibrary/src/test/java/org/bn/coders/CoderTestUtilities.java
+++ b/JavaLibrary/src/test/java/org/bn/coders/CoderTestUtilities.java
@@ -221,7 +221,15 @@ public abstract class CoderTestUtilities {
         return value;
     }
 
+    public TestIA5 createTestIA5() {
+        TestIA5 value = new TestIA5();
+        value.setValue("Hello");
+        return value;
+    }
+
     public abstract byte[] createTestPRNBytes();
+
+    public abstract byte[] createTestIA5Bytes();
 
     public TestOCT createTestOCT() {
         TestOCT value = new TestOCT();

--- a/JavaLibrary/src/test/java/org/bn/coders/DecoderTest.java
+++ b/JavaLibrary/src/test/java/org/bn/coders/DecoderTest.java
@@ -209,6 +209,11 @@ public abstract class DecoderTest {
         assertNotNull(val);
         assertEquals(val.getValue(), coderTestUtils.createTestPRN().getValue());
 
+        stream = new ByteArrayInputStream(coderTestUtils.createTestIA5Bytes());
+        TestIA5 valIA5 = decoder.decode(stream, TestIA5.class);
+        assertNotNull(valIA5);
+        assertEquals(val.getValue(), coderTestUtils.createTestIA5().getValue());
+
         stream = new ByteArrayInputStream(coderTestUtils.createTestOCTBytes());
         TestOCT valOct = decoder.decode(stream, TestOCT.class);
         assertNotNull(valOct);

--- a/JavaLibrary/src/test/java/org/bn/coders/EncoderTest.java
+++ b/JavaLibrary/src/test/java/org/bn/coders/EncoderTest.java
@@ -183,7 +183,10 @@ public abstract class EncoderTest {
         assertNotNull(encoder);
         printEncoded("TestPRN",encoder, coderTestUtils.createTestPRN());
         checkEncoded(encoder, coderTestUtils.createTestPRN(), coderTestUtils.createTestPRNBytes());
-        
+
+        printEncoded("TestIA5",encoder, coderTestUtils.createTestIA5());
+        checkEncoded(encoder, coderTestUtils.createTestIA5(), coderTestUtils.createTestIA5Bytes());
+
         printEncoded("TestOCT",encoder, coderTestUtils.createTestOCT());
         checkEncoded(encoder, coderTestUtils.createTestOCT(), coderTestUtils.createTestOCTBytes());        
     }

--- a/JavaLibrary/src/test/java/org/bn/coders/ber/BERCoderTestUtils.java
+++ b/JavaLibrary/src/test/java/org/bn/coders/ber/BERCoderTestUtils.java
@@ -141,6 +141,9 @@ public class BERCoderTestUtils extends CoderTestUtilities {
     }
 
     @Override
+    public byte[] createTestIA5Bytes() { return new byte[]{0x16, 0x05, 0x48, 0x65, 0x6C, 0x6C, 0x6F}; }
+
+    @Override
     public byte[] createTestOCTBytes() {
         return new byte[]{0x04, 0x05, 0x01, 0x02, (byte) 0xFF, 0x03, 0x04};
     }

--- a/JavaLibrary/src/test/java/org/bn/coders/per/PERAlignedCoderTestUtils.java
+++ b/JavaLibrary/src/test/java/org/bn/coders/per/PERAlignedCoderTestUtils.java
@@ -111,6 +111,11 @@ public class PERAlignedCoderTestUtils extends CoderTestUtilities {
     }
 
     @Override
+    public byte[] createTestIA5Bytes() {
+        return createTestPRNBytes();
+    }
+
+    @Override
     public byte[] createTestOCTBytes() {
         return new byte[]{0x05, 0x01, 0x02, (byte) 0xFF, 0x03, 0x04};
     }

--- a/JavaLibrary/src/test/java/org/bn/coders/per/PERUnalignedCoderTestUtils.java
+++ b/JavaLibrary/src/test/java/org/bn/coders/per/PERUnalignedCoderTestUtils.java
@@ -115,6 +115,11 @@ public class PERUnalignedCoderTestUtils extends CoderTestUtilities {
     }
 
     @Override
+    public byte[] createTestIA5Bytes() {
+        return createTestPRNBytes();
+    }
+
+    @Override
     public byte[] createTestOCTBytes() {
         return new byte[]{0x05, 0x01, 0x02, (byte) 0xFF, 0x03, 0x04};
     }


### PR DESCRIPTION
In our project we use IA5String (7bit ASCII) strings and UPER encoding. This fix make the encoder/decoder properly work with IA5String wich is similar to PrintableString, but a different tag
Verified with http://asn1-playground.oss.com/
